### PR TITLE
Move spin_table to avoid collisions with U-boot 2018.1

### DIFF
--- a/pscimon.S
+++ b/pscimon.S
@@ -173,6 +173,7 @@ dtb_ptr32:
 kernel_entry32:
 	.word 0x0
 
+.org 0x200
 .globl spin_table
 spin_table:
 	.quad 0 /* CPU0 mpentry */


### PR DESCRIPTION
Source: https://lists.freebsd.org/pipermail/freebsd-arm/2018-January/017397.html